### PR TITLE
change how sequential events are handled so they aren't overlapping

### DIFF
--- a/imagen/gcalendar.go
+++ b/imagen/gcalendar.go
@@ -74,7 +74,7 @@ func GenerateCalendarImage(events []gcalendar.Event) image.Image {
 	for _, event := range events {
 		overlapping := false
 		for i, group := range overlappingEvents {
-			if group[0].End.Before(event.Start) {
+			if group[0].End.Before(event.Start) || group[0].End.Equal(event.Start) {
 				continue
 			}
 			overlappingEvents[i] = append(group, event)


### PR DESCRIPTION
adjust so that if start and end time are the same they are not treated as overlapping (this way sequential events are sorted to the left and not staggered)